### PR TITLE
Support module paths with spaces in the path. Increase diagnostic output...

### DIFF
--- a/break/source.sh
+++ b/break/source.sh
@@ -22,12 +22,12 @@
 
 # Loads functions
 function break_load() {
-    source $(module_get_path break)/functions.sh
+    source "$(module_get_path break)"/functions.sh
 }
 
 # This function is responsible for putting the module in a useable state by
 # setting some defaults.
 function break_post_load() {
     break_interval=7200
-    break_conf_path=${HOME}/.break
+    break_conf_path="${HOME}"/.break
 }

--- a/conf/auto/source.sh
+++ b/conf/auto/source.sh
@@ -12,8 +12,8 @@
 
 # Loads the functions that extend the conf API and the conf overloads.
 function conf_auto_load() {
-    source $(module_get_path conf_auto)/functions.sh
-    source $(module_get_path conf_auto)/conf.sh
+    source "$(module_get_path conf_auto)"/functions.sh
+    source "$(module_get_path conf_auto)"/conf.sh
 }
 
 # Sets conf_auto_conf_path and loads the module configuration.
@@ -22,5 +22,5 @@ function conf_auto_load() {
 # details.
 # @calls conf_load()
 function conf_auto_post_load() {
-    conf_auto_conf_path="$HOME/.conf_auto"
+    conf_auto_conf_path="${HOME}"/.conf_auto
 }

--- a/conf/source.sh
+++ b/conf/source.sh
@@ -10,6 +10,6 @@
 # This function should be called when the module is loaded. It will load
 # functions it depends on.
 function conf_load() {
-    source $(module_get_path conf)/functions.sh
-    source $(module_get_path conf)/module.sh
+    source "$(module_get_path conf)"/functions.sh
+    source "$(module_get_path conf)"/module.sh
 }

--- a/docs/bashdoc/source.sh
+++ b/docs/bashdoc/source.sh
@@ -16,7 +16,7 @@ function docs_bashdoc_for_module() {
     local path="$docs_path/modules/$module_name"
     local module_path="$(module_get_path $module_name)"
 
-    $(module_get_path docs_bashdoc)/current/bashdoc.sh \
+    "$(module_get_path docs_bashdoc)"/current/bashdoc.sh \
         -p $module_name \
         -o $path \
         `find "$module_path" \( -name bashunit -prune \) -o \( -type f -name "*.sh" -print \)`

--- a/docs/source.sh
+++ b/docs/source.sh
@@ -26,7 +26,7 @@ function docs() {
 
     export docs_path
     export docs_template_path
-    $(module_get_path docs)/bwdocs/doc.pl $(module_get_path docs)/..
+    "$(module_get_path docs)"/bwdocs/doc.pl "$(module_get_path docs)"/..
 
     rst2html "$(module_get_path module)/docs/guide.rst" > "$docs_path/bashworks_guide.html"
 }
@@ -46,5 +46,5 @@ function docs_test() {
     export docs_template_path
     export docs_template_debug
     export docs_debug
-    $(module_get_path docs)/bwdocs/doc.pl $(module_get_path docs)/bwdocs/example
+    "$(module_get_path docs)"/bwdocs/doc.pl "$(module_get_path docs)"/bwdocs/example
 }

--- a/hack/source.sh
+++ b/hack/source.sh
@@ -5,7 +5,7 @@
 #	@License	Apache
 
 function hack_load() {
-    source $(module_get_path hack)/functions.sh
+    source "$(module_get_path hack)"/functions.sh
 }
 
 function hack_post_load() {

--- a/mlog/source.sh
+++ b/mlog/source.sh
@@ -5,7 +5,7 @@
 
 # Loads Bashinator!
 function mlog_load() {
-    source $(module_get_path mlog)/bashinator-0.3.sh
+    source "$(module_get_path mlog)"/bashinator-0.3.sh
 }
 
 # Log a message with a given security.

--- a/module/source.sh
+++ b/module/source.sh
@@ -343,9 +343,9 @@ function module_unset() {
 # location on the file system.
 # This function is used by any module _load() function.
 # Example usage:
-#   source $(module_get_path yourmodule)/functions.sh
+#   source "$(module_get_path yourmodule)"/functions.sh
 # Example submodule usage:
-#   source $(module_get_path yourmodule_submodule)/functions.sh
+#   source "$(module_get_path yourmodule_submodule)"/functions.sh
 # @param   Module name
 function module_get_path() {
     echo ${module_paths[$1]}

--- a/mpd/source.sh
+++ b/mpd/source.sh
@@ -8,7 +8,7 @@
 
 # Declares module configuration variable names.
 function mpd_load() {
-    source $(module_get_path mpd)/functions.sh
+    source "$(module_get_path mpd)"/functions.sh
 }
 
 # It sets some defaults and load the user configuration data.

--- a/mtests/bashunit/source.sh
+++ b/mtests/bashunit/source.sh
@@ -7,8 +7,8 @@
 
 # Sources mtest addons for bashunit.
 function mtests_bashunit_load() {
-    source $(module_get_path mtests_bashunit)/runner.sh
-    source $(module_get_path mtests_bashunit)/assertions.sh
+    source "$(module_get_path mtests_bashunit)"/runner.sh
+    source "$(module_get_path mtests_bashunit)"/assertions.sh
 }
 
 # Sets up environment variables required by bashunit:
@@ -30,7 +30,7 @@ function mtests_bashunit_post_load() {
 # @polite  Will try yourmodule_mtests_basshunit()
 # @calls   ResultColletor(), RunAll(), Run(), $BASHUNIT_OUTPUTTER
 function mtests_bashunit() {
-    local bashunit_dir=$(module_get_path mtests)/bashunit/current
+    local bashunit_dir="$(module_get_path mtests)"/bashunit/current
     local module_name=$1
 
     local module_overload="${module_name}_mtests_bashunit"
@@ -42,7 +42,7 @@ function mtests_bashunit() {
         fi
     fi
 
-    local module_path=$(module_get_path $module_name)
+    local module_path="$(module_get_path $module_name)"
 
     if [[ ! -d $module_path/bashunit ]]; then
         return 1

--- a/mtests/shunit/source.sh
+++ b/mtests/shunit/source.sh
@@ -12,7 +12,7 @@ function mtests_shunit_pre_load() {
 
 # Loads shUnitPlus.
 function mtests_shunit_load() {
-    source $(module_get_path mtests_shunit)/current/shUnitPlus >/dev/null 2>&1
+    source "$(module_get_path mtests_shunit)"/current/shUnitPlus >/dev/null 2>&1
 }
 
 # Runs the test suites of a module.
@@ -30,7 +30,7 @@ function mtests_shunit() {
         fi
     fi
 
-    local module_path=$(module_get_path $module_name)
+    local module_path="$(module_get_path $module_name)"
 
     if [[ ! -d $module_path/shunit ]]; then
         return 1

--- a/os/home/source.sh
+++ b/os/home/source.sh
@@ -31,8 +31,8 @@ export os_home_current_prefix=""
 
 # Loads functions and conf overloads.
 function os_home_load() {
-    source $(module_get_path os_home)/functions.sh
-    source $(module_get_path os_home)/conf.sh
+    source "$(module_get_path os_home)"/functions.sh
+    source "$(module_get_path os_home)"/conf.sh
 }
 
 # Sets $os_home_current_prefix to the first subdirectory of $os_home_repo that

--- a/os/pkg/source.sh
+++ b/os/pkg/source.sh
@@ -5,8 +5,8 @@
 
 function os_pkg_source() {
     if [[ -n `which emerge` ]]; then
-        source $(module_get_path os_pkg)/gentoo.sh
+        source "$(module_get_path os_pkg)"/gentoo.sh
     elif [[ -d /usr/ports ]]; then
-        source $(module_get_path os_pkg)/bsd.sh
+        source "$(module_get_path os_pkg)"/bsd.sh
     fi
 }

--- a/os/volume/source.sh
+++ b/os/volume/source.sh
@@ -10,7 +10,7 @@
 # This function should be called when the module is loaded, it will
 # take care of loading the conf and function submodules.
 function os_volume_load() {
-    source $(module_get_path os_volume)/functions.sh
+    source "$(module_get_path os_volume)"/functions.sh
 }
 
 # This function is responsible of preparing the module in a useable state

--- a/todo/source.sh
+++ b/todo/source.sh
@@ -4,5 +4,5 @@
 
 # Sources required functions.
 function todo_load() {
-    source $(module_get_path todo)/functions.sh
+    source "$(module_get_path todo)"/functions.sh
 }

--- a/vcs/source.sh
+++ b/vcs/source.sh
@@ -4,7 +4,7 @@
 
 # Sources functions and aliases.
 function vcs_load() {
-    source $(module_get_path vcs)/aliases.sh
+    source "$(module_get_path vcs)"/aliases.sh
 }
 
 # Sets variable defaultts.
@@ -43,7 +43,7 @@ function vcs() {
             mlog debug "Checking for $vcs_type in $vcs_src_path"
             if [[ -d ".$vcs_type" ]]; then
                 mlog debug "Found $vcs_type in $vcs_src_path"
-                source $(module_get_path vcs)/${vcs_type}.sh
+                source "$(module_get_path vcs)"/${vcs_type}.sh
             fi
         done
     fi

--- a/vps/source.sh
+++ b/vps/source.sh
@@ -23,8 +23,8 @@ function vps_pre_load() {
 
 # Source module functions and util-vserver functions
 function vps_load() {
-    source $(module_get_path vps)/functions.sh
-    source $(module_get_path vps)/conf.sh
+    source "$(module_get_path vps)"/functions.sh
+    source "$(module_get_path vps)"/conf.sh
 
     : ${UTIL_VSERVER_VARS:=/usr/lib/util-vserver/util-vserver-vars}
     test -e "$UTIL_VSERVER_VARS" || {


### PR DESCRIPTION
... in module_debug and when the module path cannot be found.

Fixes this scenario:

```
$ cat path-without-spaces/another/source.sh
#!/usr/bin/env bash

function another_load() {
    echo "I am another loaded"
}
$ cat path\ with\ a\ space/example/source.sh
#!/usr/bin/env bash

function example_load() {
    echo "I am loaded"
}
$ source bashworks/module/source.sh
$ module_repo bashworks
$ module_repo path-without-spaces/
$ module_debug | grep another
 - another, find from /home/ncpop/tmp/path-without-spaces/another
 - path-without-spaces_another, find from ./path-without-spaces/another
$ module another
I am another loaded
$ module_repo path\ with\ a\ space/
find: `/home/ncpop/tmp/space': No such file or directory
find: `/home/ncpop/tmp/path': No such file or directory
find: `/home/ncpop/tmp/with': No such file or directory
find: `/home/ncpop/tmp/a': No such file or directory
find: `/home/ncpop/tmp/space': No such file or directory
find: `/home/ncpop/tmp/path': No such file or directory
find: `/home/ncpop/tmp/a': No such file or directory
find: `/home/ncpop/tmp/with': No such file or directory
```
